### PR TITLE
[Refacor/#55] AI 요청에 따른 법률 시뮬레이터 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,9 +45,6 @@ jobs:
       - name: Copy prod yml from submodule to resources
         run: cp config/application-prod.yml src/main/resources/application-prod.yml
 
-      - name: Copy prod.yml from submodule to resources
-        run: cp config/application-prod.yml src/main/resources/application-prod.yml
-
       - name: Build JAR (skip tests)
         run: ./gradlew clean bootJar -x test
         env:

--- a/src/main/java/com/factosback/factos/domain/ai/converter/AiConverter.java
+++ b/src/main/java/com/factosback/factos/domain/ai/converter/AiConverter.java
@@ -7,9 +7,10 @@ import com.factosback.factos.domain.chat.model.ChatMessage;
 
 public class AiConverter {
 
-	public static AiRequestDto convertToAiRequestDto(ChatMessageDto.UserInputRequest request) {
+	public static AiRequestDto convertToAiRequestDto(ChatMessageDto.UserInputRequest request, String contextSummary) {
 		return AiRequestDto.builder()
 			.userInput(request.getUserInput())
+			.contextSummary(contextSummary)
 			.build();
 	}
 

--- a/src/main/java/com/factosback/factos/domain/ai/converter/AiConverter.java
+++ b/src/main/java/com/factosback/factos/domain/ai/converter/AiConverter.java
@@ -9,15 +9,13 @@ public class AiConverter {
 
 	public static AiRequestDto convertToAiRequestDto(ChatMessageDto.UserInputRequest request) {
 		return AiRequestDto.builder()
-			.case_summary(request.getCaseSummary())
-			.member_evidence(request.getMemberEvidence())
-			.opponent_claim(request.getOpponentClaim())
+			.userInput(request.getUserInput())
 			.build();
 	}
 
 	public static AiReply convertToAiReply(ChatMessageDto.AiResponse response) {
 		return AiReply.builder()
-			.content(response.getContent())
+			.claudeResponse(response.getClaudeResponse())
 			.caseNumber(response.getCaseNumber())
 			.contextSummary(response.getContextSummary())
 			.build();

--- a/src/main/java/com/factosback/factos/domain/ai/dto/AiRequestDto.java
+++ b/src/main/java/com/factosback/factos/domain/ai/dto/AiRequestDto.java
@@ -7,4 +7,5 @@ import lombok.Getter;
 @Builder
 public class AiRequestDto {
 	private String userInput;
+	private String contextSummary;
 }

--- a/src/main/java/com/factosback/factos/domain/ai/dto/AiRequestDto.java
+++ b/src/main/java/com/factosback/factos/domain/ai/dto/AiRequestDto.java
@@ -6,7 +6,5 @@ import lombok.Getter;
 @Getter
 @Builder
 public class AiRequestDto {
-	private String case_summary;
-	private String member_evidence;
-	private String opponent_claim;
+	private String userInput;
 }

--- a/src/main/java/com/factosback/factos/domain/ai/model/AiReply.java
+++ b/src/main/java/com/factosback/factos/domain/ai/model/AiReply.java
@@ -27,11 +27,11 @@ public class AiReply extends BaseEntity {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	private String content;
+	private String claudeResponse;
 
 	private Integer caseNumber;
 
-	private String contextSummary;
+	private String context;
 
 	@OneToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "chat_message_id")

--- a/src/main/java/com/factosback/factos/domain/ai/model/AiReply.java
+++ b/src/main/java/com/factosback/factos/domain/ai/model/AiReply.java
@@ -29,7 +29,7 @@ public class AiReply extends BaseEntity {
 
 	private String claudeResponse;
 
-	private Integer caseNumber;
+	private String caseNumber;
 
 	private String context;
 

--- a/src/main/java/com/factosback/factos/domain/ai/model/AiReply.java
+++ b/src/main/java/com/factosback/factos/domain/ai/model/AiReply.java
@@ -27,11 +27,14 @@ public class AiReply extends BaseEntity {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
+	// 클로드 응답
 	private String claudeResponse;
 
+	// 사건 번호 (유저 입력에 관련된 5개 정도의 사건번호 들어옴)
 	private String caseNumber;
 
-	private String context;
+	// 문맥 기억용 contextSummary
+	private String contextSummary;
 
 	@OneToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "chat_message_id")

--- a/src/main/java/com/factosback/factos/domain/ai/util/AiClient.java
+++ b/src/main/java/com/factosback/factos/domain/ai/util/AiClient.java
@@ -1,5 +1,6 @@
 package com.factosback.factos.domain.ai.util;
 
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -13,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Mono;
 
+@Profile("!local")
 @Slf4j
 @Component
 @RequiredArgsConstructor

--- a/src/main/java/com/factosback/factos/domain/ai/util/AiClient.java
+++ b/src/main/java/com/factosback/factos/domain/ai/util/AiClient.java
@@ -21,28 +21,20 @@ public class AiClient {
 	private final WebClient aiWebClient;
 
 	public ChatMessageDto.AiResponse getAiReply(AiRequestDto request) {
-		// AI 파트 기능 구현 전까지 Mock 데이터 테스트
-		return ChatMessageDto.AiResponse.builder()
-			.content("AI 분석 결과: 계약 위반 가능성이 높습니다. 이 사건은 계약서의 해석이 핵심입니다. ")
-			.caseNumber(12345)
-			.contextSummary("계약 위반 여부와 해석을 중심으로 판단해야 합니다.")
-			.build();
-
-		/**
-		 * 기존 코드
-		 */
-		// return aiWebClient.post()
-		// 	.uri("임시uri예시")
-		// 	.bodyValue(request)
-		// 	.retrieve()
-		// 	.onStatus(HttpStatusCode::isError, response ->
-		// 		response.bodyToMono(String.class)
-		// 			.flatMap(body -> {
-		// 				log.error("AI 응답 오류: {}", body);
-		// 				return Mono.error(new RestApiException(CommonErrorCode.INTERNAL_SERVER_ERROR));
-		// 			})
-		// 	)
-		// 	.bodyToMono(ChatMessageDto.AiResponse.class)
-		// 	.block();
+		return aiWebClient.post()
+			.uri("임시uri예시")
+			.bodyValue(request)
+			.retrieve()
+			.onStatus(HttpStatusCode::isError, response ->
+				response.bodyToMono(String.class)
+					.flatMap(body -> {
+						log.error("AI API 오류 응답: {} | 요청 내용: {}", body, request.getUserInput());
+						return Mono.error(new RestApiException(CommonErrorCode.INTERNAL_SERVER_ERROR));
+					})
+			)
+			.bodyToMono(ChatMessageDto.AiResponse.class)
+			.doOnSuccess(res -> log.info("AI 분석 성공 | 사건번호: {} | 문맥요약: {}", res.getCaseNumber(), res.getContextSummary()))
+			.doOnError(e -> log.error("AI 통신 실패: {}", e.getMessage()))
+			.block();
 	}
 }

--- a/src/main/java/com/factosback/factos/domain/ai/util/AiClient.java
+++ b/src/main/java/com/factosback/factos/domain/ai/util/AiClient.java
@@ -1,5 +1,6 @@
 package com.factosback.factos.domain.ai.util;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.stereotype.Component;
@@ -22,9 +23,12 @@ public class AiClient {
 
 	private final WebClient aiWebClient;
 
+	@Value("${ai.simulation.url}")
+	private String aiSimulationUrl;
+
 	public ChatMessageDto.AiResponse getAiReply(AiRequestDto request) {
 		return aiWebClient.post()
-			.uri("임시uri예시")
+			.uri(aiSimulationUrl)
 			.bodyValue(request)
 			.retrieve()
 			.onStatus(HttpStatusCode::isError, response ->

--- a/src/main/java/com/factosback/factos/domain/ai/util/MockAiClient.java
+++ b/src/main/java/com/factosback/factos/domain/ai/util/MockAiClient.java
@@ -1,0 +1,40 @@
+package com.factosback.factos.domain.ai.util;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import com.factosback.factos.domain.ai.dto.AiRequestDto;
+import com.factosback.factos.domain.chat.dto.ChatMessageDto;
+
+@Profile("local")
+@Component
+public class MockAiClient extends AiClient {
+
+	public MockAiClient() {
+		super(null);
+	}
+
+	@Override
+	public ChatMessageDto.AiResponse getAiReply(AiRequestDto request) {
+		// 요청 userInput에 따라 임의 응답 반환
+		if (request.getUserInput().contains("술집에서 술마시다가")) {
+			return ChatMessageDto.AiResponse.builder()
+				.claudeResponse("[{'type': 'text', 'text': '사용자의 상황은 술집에서 옆사람과의 시비로 인한 폭행 사건으로 보입니다. ... 무혐의 판결을 받을 수 있을 것으로 예상됩니다.'}]")
+				.caseNumber("[{'doc_id': '94도2638'}, {'doc_id': '86도1075'}, {'doc_id': '80노2214'}, {'doc_id': '86도555'}, {'doc_id': '95도852'}]")
+				.contextSummary("사용자가 술집에서 옆 사람과 시비가 붙어 폭행 사건이 발생한 것으로 보입니다. ...")
+				.build();
+		} else if (request.getUserInput().contains("기억이 끊겨 CCTV를 더 자세히 확인해 본 결과")) {
+			return ChatMessageDto.AiResponse.builder()
+				.claudeResponse("[{'type': 'text', 'text': '이 사례에서 사용자의 상황은 술집에서 상대방과 시비가 붙어 폭행 사건이 발생한 것으로 보이며 ... 정당방위 주장이 받아들여질 가능성이 높습니다.'}]")
+				.caseNumber("[{'doc_id': '84도488'}, {'doc_id': '91도3172'}, {'doc_id': '86도555'}, {'doc_id': '86노334'}, {'doc_id': '94도1905'}]")
+				.contextSummary("이 사례의 핵심은 술집에서 사용자와 상대방이 다툼 끝에 폭력 사건이 발생하였으나 ...")
+				.build();
+		}
+		// 기본 응답
+		return ChatMessageDto.AiResponse.builder()
+			.claudeResponse("[{'type': 'text', 'text': 'Mock 응답입니다.'}]")
+			.caseNumber("[]")
+			.contextSummary("Mock context summary")
+			.build();
+	}
+}

--- a/src/main/java/com/factosback/factos/domain/chat/converter/ChatConverter.java
+++ b/src/main/java/com/factosback/factos/domain/chat/converter/ChatConverter.java
@@ -10,9 +10,7 @@ public class ChatConverter {
 
 		return ChatMessage.builder()
 			.chatRoom(chatRoom)
-			.case_summary(request.getCaseSummary())
-			.member_evidence(request.getMemberEvidence())
-			.opponent_claim(request.getOpponentClaim())
+			.userInput(request.getUserInput())
 			.build();
 	}
 }

--- a/src/main/java/com/factosback/factos/domain/chat/converter/ChatConverter.java
+++ b/src/main/java/com/factosback/factos/domain/chat/converter/ChatConverter.java
@@ -3,6 +3,7 @@ package com.factosback.factos.domain.chat.converter;
 import com.factosback.factos.domain.chat.dto.ChatMessageDto;
 import com.factosback.factos.domain.chat.model.ChatMessage;
 import com.factosback.factos.domain.chat.model.ChatRoom;
+import com.factosback.factos.domain.chat.model.SenderStatus;
 
 public class ChatConverter {
 
@@ -10,6 +11,7 @@ public class ChatConverter {
 
 		return ChatMessage.builder()
 			.chatRoom(chatRoom)
+			.status(SenderStatus.MEMBER)
 			.userInput(request.getUserInput())
 			.build();
 	}

--- a/src/main/java/com/factosback/factos/domain/chat/dto/ChatMessageDto.java
+++ b/src/main/java/com/factosback/factos/domain/chat/dto/ChatMessageDto.java
@@ -9,16 +9,14 @@ public class ChatMessageDto {
 	@Getter
 	@NoArgsConstructor
 	public static class UserInputRequest {
-		private String caseSummary;
-		private String memberEvidence;
-		private String opponentClaim;
+		private String userInput;
 	}
 
 	@Getter
 	@Builder
 	public static class AiResponse {
-		private String content;
-		private Integer caseNumber;
+		private String claudeResponse;
+		private String caseNumber;
 		private String contextSummary;
 	}
 }

--- a/src/main/java/com/factosback/factos/domain/chat/model/ChatMessage.java
+++ b/src/main/java/com/factosback/factos/domain/chat/model/ChatMessage.java
@@ -34,11 +34,7 @@ public class ChatMessage extends BaseEntity {
 	// @Column(columnDefinition = "VARCHAR(15) DEFAULT 'MEMBER'")
 	// private SenderStatus status;
 
-	private String case_summary;
-
-	private String member_evidence;
-
-	private String opponent_claim;
+	private String userInput;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "chat_room_id")

--- a/src/main/java/com/factosback/factos/domain/chat/model/ChatMessage.java
+++ b/src/main/java/com/factosback/factos/domain/chat/model/ChatMessage.java
@@ -5,7 +5,10 @@ import com.factosback.factos.domain.ai.model.AiReply;
 import com.factosback.factos.global.common.model.BaseEntity;
 
 import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -30,9 +33,10 @@ public class ChatMessage extends BaseEntity {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	// @Enumerated(EnumType.STRING)
-	// @Column(columnDefinition = "VARCHAR(15) DEFAULT 'MEMBER'")
-	// private SenderStatus status;
+	@Enumerated(EnumType.STRING)
+	@Builder.Default
+	@Column(length = 15, nullable = false)
+	private SenderStatus status = SenderStatus.MEMBER;
 
 	private String userInput;
 

--- a/src/main/java/com/factosback/factos/domain/chat/model/ChatRoom.java
+++ b/src/main/java/com/factosback/factos/domain/chat/model/ChatRoom.java
@@ -37,4 +37,8 @@ public class ChatRoom extends BaseEntity {
 
 	@OneToMany(mappedBy = "chatRoom", cascade = CascadeType.ALL)
 	private List<ChatMessage> chatMessageList;
+
+	public void addChatMessage(ChatMessage chatMessage) {
+		this.chatMessageList.add(chatMessage);
+	}
 }

--- a/src/main/java/com/factosback/factos/domain/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/factosback/factos/domain/chat/repository/ChatMessageRepository.java
@@ -1,8 +1,13 @@
 package com.factosback.factos.domain.chat.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.query.Param;
 
 import com.factosback.factos.domain.chat.model.ChatMessage;
 
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
+
+	Optional<ChatMessage> findLatestByChatRoomId(@Param("chatRoomId") Long chatRoomId);
 }

--- a/src/main/java/com/factosback/factos/domain/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/factosback/factos/domain/chat/repository/ChatMessageRepository.java
@@ -3,11 +3,13 @@ package com.factosback.factos.domain.chat.repository;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import com.factosback.factos.domain.chat.model.ChatMessage;
 
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
 
+	@Query("SELECT cm FROM ChatMessage cm WHERE cm.chatRoom.id = :chatRoomId ORDER BY cm.createdAt DESC LIMIT 1")
 	Optional<ChatMessage> findLatestByChatRoomId(@Param("chatRoomId") Long chatRoomId);
 }

--- a/src/main/java/com/factosback/factos/domain/chat/service/ChatService.java
+++ b/src/main/java/com/factosback/factos/domain/chat/service/ChatService.java
@@ -18,7 +18,9 @@ import com.factosback.factos.global.error.exception.RestApiException;
 import com.factosback.factos.global.response.ApiResponse;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -58,9 +60,20 @@ public class ChatService {
 	 * 컨텍스트 조회
 	 */
 	private String getPreviousContext(Long chatRoomId) {
-		return chatMessageRepository.findLatestByChatRoomId(chatRoomId)
+		// return chatMessageRepository.findLatestByChatRoomId(chatRoomId)
+		// 	.map(ChatMessage::getAiReply)
+		// 	.map(AiReply::getContextSummary)
+		// 	.orElse("");
+
+		String context = chatMessageRepository.findLatestByChatRoomId(chatRoomId)
 			.map(ChatMessage::getAiReply)
 			.map(AiReply::getContextSummary)
 			.orElse("");
+
+		// 컨텍스트 조회 로그 추가
+		log.info("이전 컨텍스트 조회 | 채팅방 ID: {} | 컨텍스트: {}", chatRoomId,
+			context.isEmpty() ? "첫 대화" : context.substring(0, Math.min(20, context.length())) + "...");
+
+		return context;
 	}
 }

--- a/src/main/java/com/factosback/factos/domain/chat/service/ChatService.java
+++ b/src/main/java/com/factosback/factos/domain/chat/service/ChatService.java
@@ -59,7 +59,8 @@ public class ChatService {
 	/**
 	 * 컨텍스트 조회
 	 */
-	private String getPreviousContext(Long chatRoomId) {
+	@Transactional(readOnly = true)
+	String getPreviousContext(Long chatRoomId) {
 		return chatMessageRepository.findLatestByChatRoomId(chatRoomId)
 			.map(ChatMessage::getAiReply)
 			.map(AiReply::getContextSummary)

--- a/src/main/java/com/factosback/factos/domain/chat/service/ChatService.java
+++ b/src/main/java/com/factosback/factos/domain/chat/service/ChatService.java
@@ -33,9 +33,11 @@ public class ChatService {
 		Long chatRoomId, ChatMessageDto.UserInputRequest request
 	) {
 
+		String prevContextSummary = getPreviousContext(chatRoomId);
+
 		// 1. AI 분석 요청
 		ChatMessageDto.AiResponse aiResponse = aiClient.getAiReply(
-			AiConverter.convertToAiRequestDto(request)
+			AiConverter.convertToAiRequestDto(request, prevContextSummary)
 		);
 
 		// 2. 채팅방 가져오기 (현재 테스트 1L)

--- a/src/main/java/com/factosback/factos/domain/chat/service/ChatService.java
+++ b/src/main/java/com/factosback/factos/domain/chat/service/ChatService.java
@@ -51,4 +51,14 @@ public class ChatService {
 
 		return ApiResponse.createSuccess(aiResponse);
 	}
+
+	/**
+	 * 컨텍스트 조회
+	 */
+	private String getPreviousContext(Long chatRoomId) {
+		return chatMessageRepository.findLatestByChatRoomId(chatRoomId)
+			.map(ChatMessage::getAiReply)
+			.map(AiReply::getContextSummary)
+			.orElse("");
+	}
 }

--- a/src/main/java/com/factosback/factos/domain/chat/service/ChatService.java
+++ b/src/main/java/com/factosback/factos/domain/chat/service/ChatService.java
@@ -60,20 +60,20 @@ public class ChatService {
 	 * 컨텍스트 조회
 	 */
 	private String getPreviousContext(Long chatRoomId) {
-		// return chatMessageRepository.findLatestByChatRoomId(chatRoomId)
-		// 	.map(ChatMessage::getAiReply)
-		// 	.map(AiReply::getContextSummary)
-		// 	.orElse("");
-
-		String context = chatMessageRepository.findLatestByChatRoomId(chatRoomId)
+		return chatMessageRepository.findLatestByChatRoomId(chatRoomId)
 			.map(ChatMessage::getAiReply)
 			.map(AiReply::getContextSummary)
 			.orElse("");
 
-		// 컨텍스트 조회 로그 추가
-		log.info("이전 컨텍스트 조회 | 채팅방 ID: {} | 컨텍스트: {}", chatRoomId,
-			context.isEmpty() ? "첫 대화" : context.substring(0, Math.min(20, context.length())) + "...");
-
-		return context;
+		// String context = chatMessageRepository.findLatestByChatRoomId(chatRoomId)
+		// 	.map(ChatMessage::getAiReply)
+		// 	.map(AiReply::getContextSummary)
+		// 	.orElse("");
+		//
+		// // 컨텍스트 조회 로그 추가
+		// log.info("이전 컨텍스트 조회 | 채팅방 ID: {} | 컨텍스트: {}", chatRoomId,
+		// 	context.isEmpty() ? "첫 대화" : context.substring(0, Math.min(20, context.length())) + "...");
+		//
+		// return context;
 	}
 }


### PR DESCRIPTION
# #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#55 

# 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

## AI 도메인 및 채팅 기능 개선 PR
챗봇 형식으로 변경 및 AI 응답에서 context_summary 넣음Mock 클라이언트 도입을 포함한 주요 업데이트를 반영한 PR입니다. 개발 및 테스트 효율성과 향후 확장성을 고려하여 구조 전반을 개선했습니다.

### AI 챗봇 형식
contextSummary 도입으로 context 기반 AI 응답 처리
SenderStatus 추가로 발신자 구분

### AI 클라이언트 개선
실제 API 연동(aiSimulationUrl) 구현, 설정값 분리
로컬테스트용 MockAiClient 추가

### 채팅
채팅방 기준 최신 메시지 조회하기 위해 커스텀 쿼리 추가

# 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

# ✅ 체크

- [x] Reviewers 등록
- [x] Assignees 등록
- [x] Labels 등록
- [ ] CI 정상 동작 확인

# 📌 기타 참고사항
